### PR TITLE
Fix Cookie prompt from IE

### DIFF
--- a/functions/Get-MicrosoftAzureDatacenterIPRangeFile.ps1
+++ b/functions/Get-MicrosoftAzureDatacenterIPRangeFile.ps1
@@ -29,16 +29,16 @@ function Get-MicrosoftAzureDatacenterIPRangeFile {
     )
     
     $MicrosoftDownloadsURL = 'https://www.microsoft.com/en-us/download/confirmation.aspx?id=41653'
-    $DownloadPage = Invoke-WebRequest -Uri $MicrosoftDownloadsURL
-    $DownloadLink = ($DownloadPage.Links | Where-Object -FilterScript {$_.InnerText -eq 'Click here'}).href
+    $DownloadPage = Invoke-WebRequest -UseBasicParsing -Uri $MicrosoftDownloadsURL
+    $DownloadLink = ($DownloadPage.Links | Where-Object -FilterScript {$_.outerHTML -match 'Click here' -and $_.href -match '.xml'}).href[0]
         
     if ($PSCmdlet.ParameterSetName -eq 'path')
     {
-        Invoke-WebRequest -Uri $DownloadLink -OutFile $Path
+        Invoke-WebRequest -UseBasicParsing -Uri $DownloadLink -OutFile $Path
     }
     else 
     {
-        $Request = Invoke-WebRequest -Uri $DownloadLink
+        $Request = Invoke-WebRequest -UseBasicParsing -Uri $DownloadLink
         $RequestXML = Select-Xml -Content $Request.toString() -XPath /
         $RequestXML.Node
     }


### PR DESCRIPTION
##### Here's the problem:

![image](https://cloud.githubusercontent.com/assets/6472374/15874234/e23670f2-2d0a-11e6-8f23-5d0a2d0a99a6.png)
##### Proposed fix:

`-UseBasicParsing` bypasses IE. However object model changes and matching the "Click here" stuff suffers a bit. That could probably be addressed with a little more elegance than what i did there.

download.microsoft.com is awful to parse.
Just look at this mess:

```
PS C:\> $DownloadLink
https://download.microsoft.com/download/0/1/8/018E208D-54F8-44CD-AA26-CD7BC9524A8C/PublicIPs_20160606.xml
https://download.microsoft.com/download/0/1/8/018E208D-54F8-44CD-AA26-CD7BC9524A8C/PublicIPs_20160606.xml
https://download.microsoft.com/download/0/1/8/018E208D-54F8-44CD-AA26-CD7BC9524A8C/PublicIPs_20160606.xml
```

Is that GUID gonna change, the 0/1/8 stuff.. filename.. it's so unnecessarily fragile, Microsoft!
